### PR TITLE
Revert "Disable SAT>IP client support in minisatip"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,8 +277,7 @@ apps/minisatip/minisatip:
 		--disable-dvbapi \
 		--disable-dvbcsa \
 		--disable-dvbaes \
-		--disable-netcv \
-		--disable-satipc
+		--disable-netcv
 	make -C apps/minisatip -j $(CPUS) \
 	  CC=$(TOOLCHAIN)/bin/sh4-linux-gcc \
 	  EXTRA_CFLAGS="-O2 -I$(CURDIR)/kernel/include"


### PR DESCRIPTION
This reverts commit d0d5cbfcc021171f165c8fc2d69f289fe82aa7c1.