### PR TITLE
Don't preserve ownership when copyin in fs-add

### DIFF
--- a/tools/do_min_fs.py
+++ b/tools/do_min_fs.py
@@ -584,7 +584,7 @@ print '     ' + 30*'='  + '\n'
 gen_fs(library_list, boot_type)
 run_cmd('rm -v fs/etc/inittabBB fs/etc/init.d/rcSBB')
 for d in extradir_list:
-  run_cmd('cp -av ' + d + '/* fs')
+  run_cmd('cp -Rv ' + d + '/* fs')
 f = open("fs/etc/motd")
 b = f.read(1024*1024)
 f.close()


### PR DESCRIPTION
We don't want the local copy's file permissions to be reflected in the target firmware filesystem. Should fix #51.