### PR TITLE
Fix tools/Makefile so i2c_mangle.ko actually gets built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,8 @@ kernel/arch/sh/boot/uImage.gz: kernel/drivers/usb/serial/cp210x.ko fs.cpio
 tools/i2c_mangle.ko: tools/i2c_mangle.c
 	make -C tools ARCH=sh CROSS_COMPILE=$(TOOLCHAIN)/bin/sh4-linux- all
 
-.PHONY: kernel-modules tools/i2c_mangle.ko
-kernel-modules: kernel/drivers/usb/serial/cp210x.ko
+.PHONY: kernel-modules
+kernel-modules: kernel/drivers/usb/serial/cp210x.ko tools/i2c_mangle.ko
 
 .PHONY: kernel
 kernel: kernel/arch/sh/boot/uImage.gz

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -11,3 +11,4 @@ i2c_mangle.o
 i2c_mangle.ko
 Module.symvers
 modules.order
+.tmp_versions

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 obj-m=i2c_mangle.o
 
 all:
-	make -C $(PWD)/kernel ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(PWD)/tools modules
+	make -C ../kernel ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) modules
 
 clean:
-	make -C $(PWD)/kernel ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(PWD)/tools clean
+	make -C ../kernel ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) M=$(shell pwd) clean


### PR DESCRIPTION
@perexg what does this module actually do? It seems to have been left out of my builds accidentally, but things seem to work nevertheless?