### PR TITLE
Chrony optimizations

### DIFF
--- a/fs-add/etc/init.d/chronyd
+++ b/fs-add/etc/init.d/chronyd
@@ -11,7 +11,13 @@ done
 mkdir -p /etc/sysconfig/chrony
 ln -sf /etc/sysconfig/chrony /var/lib/chrony
 
-# sync once before daemonizing so we can notify minisatip startup that 
+# use custom config if exists
+if test -r /etc/sysconfig/chronyd.conf; then
+  rm /etc/chronyd.conf
+  ln -s /etc/sysconfig/chronyd.conf /etc/chronyd.conf
+fi
+
+# sync once before daemonizing so we can notify minisatip startup that
 # we have time
 chronyd -f /etc/chronyd.conf -n -q
 logger -p local0.notice "chronyd time synchronized to $(date), signaling minisatip startup"

--- a/fs-add/etc/init.d/rcS
+++ b/fs-add/etc/init.d/rcS
@@ -8,7 +8,7 @@ AXECFG=${AXECFG:7:255}
 
 # remount root filesystem in rw mode
 busybox mount -o remount,rw /
-# Create all symbolic links. 
+# Create all symbolic links.
 /bin/busybox --install -s
 
 # Date
@@ -33,7 +33,7 @@ mv /var /var.2
 mkdir /tmp/var
 ln -s /tmp/var /var
 rm -rf /var.2
-mkdir -p /tmp/var/run /tmp/var/log /tmp/var/spool
+mkdir -p /tmp/var/run /tmp/var/log /tmp/var/spool /tmp/var/lib
 
 # sysctl.conf
 sysctl -q -p


### PR DESCRIPTION
The directory `/var/lib` (`/tmp/var/lib`) was missing, so the symlink from `/var/lib/chrony` to `/etc/sysconfig/chrony` could not be created.

Also added support to use a custom `chronyd.conf` in `/etc/sysconfig/`.
This is required to use a custom/local NTP server.